### PR TITLE
Fix toast listener effect

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- use an empty dependency array in `useToast` to avoid re-adding listeners

## Testing
- `npm run lint` *(fails: 4 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6871a1b42df883288b8f27b754c3b6ae