### PR TITLE
Add animated landing image below header

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -72,3 +72,32 @@
 .button-gradient {
   @apply bg-gradient-to-r from-primary to-[#22c55e] hover:opacity-90 transition-opacity rounded-full;
 }
+
+@keyframes border-move {
+  from {
+    background-position: 0 0;
+  }
+  to {
+    background-position: 200% 0;
+  }
+}
+
+.border-animated {
+  position: relative;
+}
+
+.border-animated::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  padding: 2px;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #4ade80, #22c55e, #4ade80);
+  background-size: 200% 100%;
+  animation: border-move 5s linear infinite;
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  pointer-events: none;
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -18,6 +18,13 @@ const Index = () => {
     <div className="min-h-screen bg-black text-foreground">
       <Navigation />
 
+      {/* Landing Image */}
+      <div className="flex justify-center mt-24 px-4">
+        <div className="border-animated rounded-xl overflow-hidden w-full max-w-4xl">
+          <img src="/lovable-uploads/landing_1.png" alt="Landing" className="w-full h-auto" />
+        </div>
+      </div>
+
       {/* Hero Section */}
       <motion.section
         initial={{ opacity: 0, y: 20 }}


### PR DESCRIPTION
## Summary
- show an image below the header
- animate its border

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6871ce6ffcb483289366367299592a01