### PR TITLE
Change carousel background to black

### DIFF
--- a/src/components/LogoCarousel.tsx
+++ b/src/components/LogoCarousel.tsx
@@ -14,7 +14,7 @@ const LogoCarousel = () => {
   const extendedLogos = [...logos, ...logos, ...logos];
 
   return (
-    <div className="w-full overflow-hidden bg-background/50 backdrop-blur-sm py-12 mt-20">
+    <div className="w-full overflow-hidden bg-black py-12 mt-20">
       <motion.div 
         className="flex space-x-16"
         initial={{ opacity: 0, x: "0%" }}


### PR DESCRIPTION
## Summary
- match the logo carousel background color with the page's background

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type, etc.)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871ced54c2483289f5345641c86f969