### PR TITLE
Fix invisible page by enforcing dark background fallback

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -37,6 +37,8 @@
   body {
     @apply bg-background text-foreground font-sans antialiased;
     font-feature-settings: "rlig" 1, "calt" 1;
+    background-color: #000;
+    color: #fff;
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure black background and white text fallback in base styles

## Testing
- `npm run build:dev`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68721d7290a8832895f19e327b9ff337