### PR TITLE
Fix duplicate landing image

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -17,14 +17,6 @@ const Index = () => {
   return (
     <div className="min-h-screen bg-black text-foreground">
       <Navigation />
-
-      {/* Landing Image */}
-      <div className="flex justify-center mt-24 px-4">
-        <div className="border-animated rounded-xl overflow-hidden w-full max-w-4xl">
-          <img src="/lovable-uploads/landing_1.png" alt="Landing" className="w-full h-auto" />
-        </div>
-      </div>
-
       {/* Hero Section */}
       <motion.section
         initial={{ opacity: 0, y: 20 }}


### PR DESCRIPTION
## Summary
- remove duplicated landing_1.png at top of Index page

## Testing
- `npm test`
- `npm run lint` *(fails: no-implicit-any, no-empty-object-type, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6872211ae1c88328bb2f9b7dd5f11e9c