### PR TITLE
Fix Vercel static asset routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,8 @@
 {
   "version": 2,
   "builds": [{ "src": "package.json", "use": "@vercel/static-build", "config": { "distDir": "dist" }}],
-  "routes": [{ "src": "/(.*)", "dest": "/index.html" }]
+  "routes": [
+    { "handle": "filesystem" },
+    { "src": "/(.*)", "dest": "/index.html" }
+  ]
 }


### PR DESCRIPTION
## Summary
- ensure Vercel serves built static assets before falling back to `index.html`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687220e18370832894a263487c715697