### PR TITLE
Proxy contact form submissions

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -24,9 +24,17 @@ function saveSubmission(data: any) {
   fs.writeFileSync(submissionsFile, JSON.stringify(submissions, null, 2));
 }
 
-app.post('/api/contact', (req, res) => {
+app.post('/api/contact', async (req, res) => {
   try {
     saveSubmission(req.body);
+    await fetch(
+      'https://script.google.com/macros/s/AKfycby5zKHbPimSXw9DxJ2WkSLUA-C0Oe_w1nF2DipuVWZ1Nr03ROqyP8EcZ6lzf2MM7kYqeQ/exec',
+      {
+        method: 'POST',
+        body: JSON.stringify(req.body),
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
     res.status(200).json({ success: true });
   } catch (error) {
     console.error('Error saving submission', error);


### PR DESCRIPTION
## Summary
- send contact form data to `/api/contact` again
- forward requests from the server to the Google Apps Script endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68721c2383a08328aaf0d91504c910d5